### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/public/js/CKEditor/plugins/leaflet/scripts/leaflet-providers/leaflet-providers.js
+++ b/public/js/CKEditor/plugins/leaflet/scripts/leaflet-providers/leaflet-providers.js
@@ -61,10 +61,10 @@
 	//jshint maxlen:220
 	L.TileLayer.Provider.providers = {
 		OpenStreetMap: {
-			url: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			options: {
 				attribution:
-					'&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
+					'&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap</a>, ' +
 					'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
 			},
 			variants: {


### PR DESCRIPTION
I would like to suggest using the now preferred https://tile.openstreetmap.org URL instead of the current one (`{s}.`), see

https://github.com/openstreetmap/operations/issues/737

Similarly updates attribution, though leaving license as-is.